### PR TITLE
User profile start trip button

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
-
   def show
+    if current_user.nil? 
+      flash[:error] = "Please log in to continue"
+      redirect_to '/'
+    end
   end
-
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
       <p>
       <%= image_tag('logos/escape_nav.png', height: '60px') %>
       <%= "Hi, #{current_user.first_name}" if current_user %>
-      <%= link_to 'About' %>
+      <%= link_to 'About', '/about' %>
       <%= link_to 'Log Out', '/logout' if current_user %>
       </p>
     </nav>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,7 @@
 <center>
   <h1>Hello, <%= current_user.first_name %>!</h1>
   <h3>Profile Coming Soon</h3>
+  <section>
+    <%= link_to 'Start a New Trip', '/search' %>
+  </section>
 </center>

--- a/spec/features/users/can_view_profile_spec.rb
+++ b/spec/features/users/can_view_profile_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe "As a User" do
+  describe "When I have logged in successfully" do
+    it "I am on the profile page and can see a button 'Start a New Trip'" do
+      user = create(:user)
+     
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      
+      visit '/profile'
+            
+      click_on 'Start a New Trip'
+
+      expect(current_path).to eq('/search')
+    end 
+  end 
+  describe "When I am not logged in" do
+    describe "I try to visit the profile page" do
+      it "I am redirected to log in page and see a 'Please log in to continue' message" do
+        visit '/profile'
+        expect(current_path).to eq('/')
+        expect(page).to have_content("Please log in to continue")
+      end
+    end
+  end
+end 

--- a/spec/features/users/user_can_view_about_page_spec.rb
+++ b/spec/features/users/user_can_view_about_page_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe 'A User or Visitor' do
   it "can click on 'About' and learn about the application" do
-    # visit '/'
-    # click_on 'About'
     visit '/about'
     expect(current_path).to eq '/about'
     expect(".about").to_not be_empty


### PR DESCRIPTION
**Functionality:**
As a logged in user, I am redirected to my profile page and see a "Start a New Trip" button. When I click on it, I am redirected to '/search'


**Testing:**
Fully tested for both logged in user and non-logged in user. 


**Related Issues:**
#28 